### PR TITLE
Get PDLs from a single merged repository

### DIFF
--- a/get-pdls.sh
+++ b/get-pdls.sh
@@ -2,25 +2,14 @@
 
 set -e
 
-get_pdl() {
-	local path=$1
-	local repo=$2
-	local branch=$3
+path=pdl
+repo=https://github.com/janvrany/Pharo-ArchC-PDL.git
+branch=master
 
-	if [ ! -d "$path" ]; then
-		mkdir -p "$path"
-		git clone --branch "$branch" "$repo" "$path"
-	elif [ -d "$path/.git" ]; then
-		echo "$path"
-		git -C "$path" pull
-	fi
-}
-
-get_pdl pdl/arm 	https://github.com/shingarov/arm.git		good
-get_pdl pdl/x86 	https://github.com/shingarov/x86.git		bee
-get_pdl pdl/powerpc	https://github.com/shingarov/powerpc.git	good
-get_pdl pdl/riscv	https://github.com/shingarov/riscv.git 		master
-get_pdl pdl/mips 	https://github.com/shingarov/mips.git		master
-get_pdl pdl/sparc	https://github.com/shingarov/sparc.git 		gdb-descriptors
-
-
+if [ ! -d "$path" ]; then
+	mkdir -p "$path"
+	git clone --branch "$branch" "$repo" "$path"
+elif [ -d "$path/.git" ]; then
+	echo "$path"
+	git -C "$path" pull
+fi


### PR DESCRIPTION
This commit changes `get-pdls.sh` so that it fetches PDLs
from a single repository [[1]] instead from multiple scattered
repositories.

The merged repository was created by a script [merge-pdls.sh][2]

[1]: https://github.com/janvrany/Pharo-ArchC-PDL.git
[2]: https://github.com/janvrany/Pharo-ArchC-PDL/commit/98472489d1a0188044868ea946a89a4d547d6b6f#diff-0fc3247816de9a411d5a5d62b322faf9a1be06fa4258034dd587451c43b7bd1a