### PR TITLE
RISC-V: add support for F, D and A extensions

### DIFF
--- a/src/ArchC-Core/AcAsmFormatMapChunk.class.st
+++ b/src/ArchC-Core/AcAsmFormatMapChunk.class.st
@@ -19,9 +19,17 @@ AcAsmFormatMapChunk class >> map: aDictionary named: nameString source: sourceSt
 
 { #category : #'API - assembly' }
 AcAsmFormatMapChunk >> assembler [ 
-	| alternativeParsers nilForEmptySym defaultInt |
+	| alternativeParsers defaultInt mappings |
 	defaultInt := nil.
-	alternativeParsers := self map forwardMap associations  collect: [ :ass |
+	mappings := self map forwardMap associations.
+	"
+	Sort mappings by descending key length. This is needed
+	for cases where one key may be prefix of another. This
+	way, longer keys are tried before shorter.
+	"
+	mappings sort: [ :a :b | a key size > b key size ].
+
+	alternativeParsers := mappings collect: [ :ass |
 		| sym i |
 		i := ass value.
 		sym := ass key.
@@ -29,7 +37,7 @@ AcAsmFormatMapChunk >> assembler [
 			ifTrue: [ defaultInt:= i. nil ]
 			ifFalse: [ sym asParser ==> i K ]].
 	alternativeParsers := alternativeParsers asOrderedCollection.
-	nilForEmptySym := alternativeParsers remove: nil ifAbsent: [ #NoEmpty ].
+	alternativeParsers remove: nil ifAbsent: [ #NoEmpty ].
 	alternativeParsers := PPChoiceParser withAll: alternativeParsers.
 	defaultInt isNil ifFalse: [ alternativeParsers :=
 		alternativeParsers optional ==> [ :x | x ifNil: [defaultInt] ] ] .

--- a/src/ArchC-RISCV-Tests/AcRISCVTests.class.st
+++ b/src/ArchC-RISCV-Tests/AcRISCVTests.class.st
@@ -47,6 +47,23 @@ AcRISCVTests >> testRiscvADDI [
 ]
 
 { #category : #'tests - RISC-V' }
+AcRISCVTests >> testRiscvAMOXOR_D [
+	| insn |
+
+	insn := pdl assemble: 'amoxor.d.aqrl t1, t2, t3'.
+	self assert: insn asByteArray = #[16r2F 16rB3 16rC3 16r27].
+
+	insn := pdl disassemble: insn asByteArray.
+	self assert: insn = 'amoxor.d.aqrl t1, t2, t3'.
+
+	insn := pdl assemble: 'amoxor.d t1, t2, t3'.
+	self assert: insn asByteArray = #[16r2F 16rB3 16rC3 16r21].
+
+	insn := pdl disassemble: insn asByteArray.
+	self assert: insn = 'amoxor.d t1, t2, t3'.
+]
+
+{ #category : #'tests - RISC-V' }
 AcRISCVTests >> testRiscvAUIPC [
 	| insn |
 

--- a/src/ArchC-RISCV-Tests/AcRISCVTests.class.st
+++ b/src/ArchC-RISCV-Tests/AcRISCVTests.class.st
@@ -76,6 +76,45 @@ AcRISCVTests >> testRiscvEBREAK [
 ]
 
 { #category : #'tests - RISC-V' }
+AcRISCVTests >> testRiscvFADD_S [
+   | insn |
+
+	insn := pdl assemble: 'fadd.s fa0, fs0, fs1'.
+	self assert: insn asByteArray = #[16r53 16r75 16r94 16r00].
+
+	insn := pdl disassemble: insn asByteArray.
+	self assert: insn = 'fadd.s fa0, fs0, fs1'.
+
+	insn := pdl assemble: 'fadd.s fa0, fs0, fs1, rup'.
+	self assert: insn asByteArray = #[16r53 16r35 16r94 16r00].
+
+	insn := pdl disassemble: insn asByteArray.
+	self assert: insn = 'fadd.s fa0, fs0, fs1, rup'.
+]
+
+{ #category : #'tests - RISC-V' }
+AcRISCVTests >> testRiscvFLD [
+   | insn |
+
+	insn := pdl assemble: 'fld fa0, sp, 8'.
+	self assert: insn asByteArray = #[16r07 16r35 16r81 16r00].
+
+	insn := pdl disassemble: insn asByteArray.
+	self assert: insn = 'fld fa0, sp, 8'.
+]
+
+{ #category : #'tests - RISC-V' }
+AcRISCVTests >> testRiscvFSD [
+   | insn |
+
+	insn := pdl assemble: 'fsd fa0, s1, 10'.
+	self assert: insn asByteArray = #[16r27 16r35 16r95 16r00].
+
+	insn := pdl disassemble: insn asByteArray.
+	self assert: insn = 'fsd fa0, s1, 10'.
+]
+
+{ #category : #'tests - RISC-V' }
 AcRISCVTests >> testRiscvJAL [
 	| insn |
 

--- a/src/ArchC-RISCV/AcRISCVOpcodeParser.class.st
+++ b/src/ArchC-RISCV/AcRISCVOpcodeParser.class.st
@@ -25,6 +25,11 @@ AcRISCVOpcodeParser class >> parseFile: fileName in: path [
 ]
 
 { #category : #'parsing - bitfields' }
+AcRISCVOpcodeParser >> aqrl [
+	^ 'aqrl' asParser trim
+]
+
+{ #category : #'parsing - bitfields' }
 AcRISCVOpcodeParser >> bimm12hi [
 	^ 'bimm12hi' asParser trim
 
@@ -78,6 +83,16 @@ AcRISCVOpcodeParser >> funct5 [
 	"
 	AcRISCVOpcodeParser parse: '31..27=32 ' startingAt: #funct5
 	"
+]
+
+{ #category : #'parsing - bitfields' }
+AcRISCVOpcodeParser >> funct5_h3 [
+	^ ('31..29=' asParser , self number) trim ==> [ :nodes | nodes second ]
+]
+
+{ #category : #'parsing - bitfields' }
+AcRISCVOpcodeParser >> funct5_l2 [
+	^ ('28..27=' asParser , self number) trim ==> [ :nodes | nodes second ]
 ]
 
 { #category : #'parsing - bitfields' }
@@ -275,6 +290,7 @@ AcRISCVOpcodeParser >> start [
 	/ self type_Rsys
 	/ self type_Rfd
 	/ self type_R4fd
+	/ self type_Ra
 
 	/ self type_Ish
 	/ self type_Ishw
@@ -575,6 +591,54 @@ AcRISCVOpcodeParser >> type_R4fd [
 	"
 	AcRISCVOpcodeParser parse: 'fmadd.s   rd rs1 rs2 rs3 rm 26..25=0 6..2=0x10 1..0=3' startingAt: #type_R4fd
 
+	"
+]
+
+{ #category : #parsing }
+AcRISCVOpcodeParser >> type_Ra [
+	^ (self mnemonic , self rd , self rs1, self rs2 , self aqrl, self funct5_h3, self funct5_l2, self funct3 , self opcode
+	==> [ :nodes |
+
+		| internalBindings instr |
+
+		internalBindings := Dictionary new.
+		internalBindings at: 'funct5_h3' put: (nodes at: 6).
+		internalBindings at: 'funct5_l2' put: (nodes at: 7).
+		internalBindings at: 'funct3' put: (nodes at: 8).
+		internalBindings at: 'opcode'put: (nodes at: 9).
+
+		instr := ProcessorInstructionDeclaration new.
+		instr name: nodes first.
+		instr format: 'Type_Ra'.
+		instr internalBindings: internalBindings.  
+		instr addSyntax: '("' , nodes first , '%aqrl %gpr, %gpr, %gpr", aqrl, rd, rs1, rs2)'.
+
+		instr
+		])
+	/ (self mnemonic , self rd , self rs1, self funct_rs2 , self aqrl, self funct5_h3, self funct5_l2, self funct3 , self opcode
+	==> [ :nodes |
+
+		| internalBindings instr |
+
+		internalBindings := Dictionary new.
+		internalBindings at: 'funct5_h3' put: (nodes at: 6).
+		internalBindings at: 'funct5_l2' put: (nodes at: 7).
+		internalBindings at: 'funct3' put: (nodes at: 8).
+		internalBindings at: 'opcode'put: (nodes at: 9).
+		internalBindings at: 'rs2' put: (nodes at: 4).
+
+		instr := ProcessorInstructionDeclaration new.
+		instr name: nodes first.
+		instr format: 'Type_Ra'.
+		instr internalBindings: internalBindings.  
+		instr addSyntax: '("' , nodes first , '%aqrl %gpr, %gpr", aqrl, rd, rs1)'.
+
+		instr
+		])
+	
+
+	"
+	AcRISCVOpcodeParser parse: 'amoadd.w    rd rs1 rs2      aqrl 31..29=0 28..27=0 14..12=2 6..2=0x0B 1..0=3' startingAt: #type_Ra
 	"
 ]
 

--- a/src/ArchC-RISCV/AcRISCVOpcodeParser.class.st
+++ b/src/ArchC-RISCV/AcRISCVOpcodeParser.class.st
@@ -43,6 +43,15 @@ AcRISCVOpcodeParser >> fm [
 ]
 
 { #category : #'parsing - bitfields' }
+AcRISCVOpcodeParser >> fmt [
+	^ ('26..25=' asParser , self number) trim ==> [ :nodes | nodes second ]
+
+	"
+	AcRISCVOpcodeParser parse: '26..25=0 ' startingAt: #fmt
+	"
+]
+
+{ #category : #'parsing - bitfields' }
 AcRISCVOpcodeParser >> funct12 [
 	^ ('31..20=' asParser , self number) trim ==> [ :nodes | nodes second ]
 
@@ -63,12 +72,26 @@ AcRISCVOpcodeParser >> funct3 [
 ]
 
 { #category : #'parsing - bitfields' }
+AcRISCVOpcodeParser >> funct5 [
+	^ ('31..27=' asParser , self number) trim ==> [ :nodes | nodes second ]
+
+	"
+	AcRISCVOpcodeParser parse: '31..27=32 ' startingAt: #funct5
+	"
+]
+
+{ #category : #'parsing - bitfields' }
 AcRISCVOpcodeParser >> funct7 [
 	^ ('31..25=' asParser , self number) trim ==> [ :nodes | nodes second ]
 
 	"
 	 AcRISCVOpcodeParser parse: '31..25=32 ' startingAt: #func7"
 
+]
+
+{ #category : #'parsing - bitfields' }
+AcRISCVOpcodeParser >> funct_rs2 [
+	^ ('24..20=' asParser , self number) trim ==> [ :nodes | nodes second ]
 ]
 
 { #category : #'parsing - bitfields' }
@@ -179,6 +202,16 @@ AcRISCVOpcodeParser >> rd0 [
 ]
 
 { #category : #'parsing - bitfields' }
+AcRISCVOpcodeParser >> rm [
+	^ ('rm' asParser trim ==> [ :nodes | nil ])
+	/ (('14..12=' asParser , self number) trim ==> [ :nodes | nodes second ])
+
+	"
+	AcRISCVOpcodeParser new rm
+	"
+]
+
+{ #category : #'parsing - bitfields' }
 AcRISCVOpcodeParser >> rs1 [
 	^ 'rs1' asParser trim
 
@@ -194,6 +227,11 @@ AcRISCVOpcodeParser >> rs10 [
 AcRISCVOpcodeParser >> rs2 [
 	^ 'rs2' asParser trim
 
+]
+
+{ #category : #'parsing - bitfields' }
+AcRISCVOpcodeParser >> rs3 [
+	^ 'rs3' asParser trim
 ]
 
 { #category : #'parsing - bitfields' }
@@ -235,6 +273,8 @@ AcRISCVOpcodeParser >> start [
 	^ 
 	  self type_R
 	/ self type_Rsys
+	/ self type_Rfd
+	/ self type_R4fd
 
 	/ self type_Ish
 	/ self type_Ishw
@@ -259,7 +299,6 @@ AcRISCVOpcodeParser >> start [
 	AcRISCVOpcodeParser parseFile: (AcProcessorDescriptions baseDirectory , 'riscv/riscv-opcodes/opcodes-rv32i')
 	AcRISCVOpcodeParser parseFile: (AcProcessorDescriptions baseDirectory , 'riscv/riscv-opcodes/opcodes-rv64i')
 	"
-
 ]
 
 { #category : #'parsing - bitfields' }
@@ -309,6 +348,7 @@ AcRISCVOpcodeParser >> type_I [
 		instr name: nodes first.
 		instr format: 'Type_I'.
 		instr internalBindings: internalBindings.  
+		instr addSyntax: '("' , nodes first , ' %fpr, %gpr, %exp", rd, rs1, imm, opcode=7)'.
 		instr addSyntax: '("' , nodes first , ' %gpr, %gpr, %exp", rd, rs1, imm)'.
 
 		instr
@@ -504,6 +544,106 @@ AcRISCVOpcodeParser >> type_R [
 ]
 
 { #category : #parsing }
+AcRISCVOpcodeParser >> type_R4fd [
+	^ (self mnemonic , self rd , self rs1, self rs2, self rs3 , self rm, self fmt , self opcode
+	==> [ :nodes |
+
+		| internalBindings rm instr |
+
+		internalBindings := Dictionary new.
+		internalBindings at: 'fmt' put: (nodes at: 7).
+		rm := nodes at: 6.
+		rm notNil ifTrue: [ 
+			internalBindings at: 'rm' put: rm.
+		].
+		internalBindings at: 'opcode' put: (nodes at: 8).
+
+		instr := ProcessorInstructionDeclaration new.
+		instr name: nodes first.
+		instr format: 'Type_R4fd'.
+		instr internalBindings: internalBindings.  
+		rm isNil ifTrue: [
+			instr addSyntax: '("' , nodes first , ' %fpr, %fpr, %fpr, %fpr", rd, rs1, rs2, rs3, rm=7)'.
+			instr addSyntax: '("' , nodes first , ' %fpr, %fpr, %fpr, %fpr, %rm", rd, rs1, rs2, rs3, rm)'.
+		] ifFalse: [ 
+			instr addSyntax: '("' , nodes first , ' %fpr, %fpr, %fpr, %fpr", rd, rs1, rs2, rs3)'.
+		].
+
+		instr
+		])
+
+	"
+	AcRISCVOpcodeParser parse: 'fmadd.s   rd rs1 rs2 rs3 rm 26..25=0 6..2=0x10 1..0=3' startingAt: #type_R4fd
+
+	"
+]
+
+{ #category : #parsing }
+AcRISCVOpcodeParser >> type_Rfd [
+	^ (self mnemonic , self rd , self rs1, self funct_rs2, self funct5 , self rm, self fmt , self opcode
+	==> [ :nodes |
+
+		| internalBindings rm instr |
+
+		internalBindings := Dictionary new.
+		internalBindings at: 'funct5' put: (nodes at: 5).
+		internalBindings at: 'fmt' put: (nodes at: 7).
+		internalBindings at: 'rs2' put: (nodes at: 4).
+		rm := nodes at: 6.
+		rm notNil ifTrue: [ 
+			internalBindings at: 'rm' put: rm.
+		].
+		internalBindings at: 'opcode' put: (nodes at: 8).
+
+		instr := ProcessorInstructionDeclaration new.
+		instr name: nodes first.
+		instr format: 'Type_Rfd'.
+		instr internalBindings: internalBindings.  
+		rm isNil ifTrue: [
+			instr addSyntax: '("' , nodes first , ' %fpr, %fpr", rd, rs1, rm=7)'.
+			instr addSyntax: '("' , nodes first , ' %fpr, %fpr, %rm", rd, rs1, rm)'.
+		] ifFalse: [ 
+			instr addSyntax: '("' , nodes first , ' %fpr, %fpr", rd, rs1)'.
+		].
+
+		instr
+		])
+	/ (self mnemonic , self rd , self rs1, self rs2, self funct5 , self rm, self fmt , self opcode
+	==> [ :nodes |
+
+		| internalBindings rm instr |
+
+		internalBindings := Dictionary new.
+		internalBindings at: 'funct5' put: (nodes at: 5).
+		internalBindings at: 'fmt' put: (nodes at: 7).
+		rm := nodes at: 6.
+		rm notNil ifTrue: [ 
+			internalBindings at: 'rm' put: rm.
+		].
+		internalBindings at: 'opcode' put: (nodes at: 8).
+
+		instr := ProcessorInstructionDeclaration new.
+		instr name: nodes first.
+		instr format: 'Type_Rfd'.
+		instr internalBindings: internalBindings.  
+		rm isNil ifTrue: [
+			instr addSyntax: '("' , nodes first , ' %fpr, %fpr, %fpr", rd, rs1, rs2, rm=7)'.
+			instr addSyntax: '("' , nodes first , ' %fpr, %fpr, %fpr, %rm", rd, rs1, rs2, rm)'.
+		] ifFalse: [ 
+			instr addSyntax: '("' , nodes first , ' %fpr, %fpr, %fpr", rd, rs1, rs2)'.
+		].
+
+		instr
+		])
+
+	"
+	AcRISCVOpcodeParser parse: 'fadd.s    rd rs1 rs2      31..27=0x00 rm       26..25=0 6..2=0x14 1..0=3' startingAt: #type_Rfd
+	AcRISCVOpcodeParser parse: 'fsqrt.s   rd rs1 24..20=0 31..27=0x0B rm       26..25=0 6..2=0x14 1..0=3' startingAt: #type_Rfd
+
+	"
+]
+
+{ #category : #parsing }
 AcRISCVOpcodeParser >> type_Rsys [
 	^ self mnemonic , self rd0 , self rs1, self rs2 , self funct7 , self funct3 , self opcode
 	==> [ :nodes |
@@ -545,6 +685,7 @@ AcRISCVOpcodeParser >> type_S [
 		instr name: nodes first.
 		instr format: 'Type_S'.
 		instr internalBindings: internalBindings.
+		instr addSyntax: '("' , nodes first , ' %fpr, %gpr, %exp", rs1, rs2, imm1+imm2, opcode=39)'.
 		instr addSyntax: '("' , nodes first , ' %gpr, %gpr, %exp", rs1, rs2, imm1+imm2)'.
 
 		instr


### PR DESCRIPTION
This commit adds support for F, D and A extensions, completing the support for RV64G. 
FYI: @KenDickey