### PR TITLE
Fix disassembly of symbolic instructions

### DIFF
--- a/src/ArchC-Core-Tests/TextDisassemblyTest.class.st
+++ b/src/ArchC-Core-Tests/TextDisassemblyTest.class.st
@@ -42,6 +42,15 @@ TextDisassemblyTest >> testPowerOriSymbolic [
 ]
 
 { #category : #'tests - powerpc' }
+TextDisassemblyTest >> testPowerOriSymbolic2 [
+	| encoding disasm |
+
+	encoding := (2r01100010100 toBitVector: 11) , ('dstReg' toBitVector: 5) , (16r0001 toBitVector: 16).
+	disasm := AcProcessorDescriptions powerpc disassemble: encoding.
+	self assert: disasm equals: 'ori {dstReg}, 20, 0x1'
+]
+
+{ #category : #'tests - powerpc' }
 TextDisassemblyTest >> testPowerSc [
 	| instr text |
 	instr := AcProcessorDescriptions powerpc decode: 16r44000002 .

--- a/src/ArchC-Core/AcAsmFormatMapChunk.class.st
+++ b/src/ArchC-Core/AcAsmFormatMapChunk.class.st
@@ -47,11 +47,20 @@ AcAsmFormatMapChunk >> assembler [
 
 { #category : #'API - disassembly' }
 AcAsmFormatMapChunk >> disassembleTo: aWriteStream operands: ops inEnvironment: aDictionary [
-	| op value symbolic |
+	| op value |
 	op := ops removeFirst operand.
 	value := aDictionary at: op.
-	symbolic := (self map backLookup: value) name.
-	aWriteStream nextPutAll: symbolic
+	(value isAST and:[value isSymbolic]) ifTrue: [
+		| symbol |
+
+		symbol := value sym.
+		aWriteStream nextPut: ${;  nextPutAll: symbol; nextPut: $}.
+	] ifFalse: [ 
+		| name |
+
+		name := (self map backLookup: value) name.
+		aWriteStream nextPutAll: name
+	].
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
...when symbolic value is "map" chunk (like `%gpr`), for example:

    addi {dstReg}, 20, 1