### PR TITLE
Fix assembly and disassembly of generic mnemonics wrt extended mnemonics

### DIFF
--- a/src/ArchC-Core-Tests/AcAsmFormatTest.class.st
+++ b/src/ArchC-Core-Tests/AcAsmFormatTest.class.st
@@ -34,7 +34,7 @@ AcAsmFormatTest >> proc: parser spec: aSetAsmString operandKeys: k operandValues
 	].
 	env := Dictionary newFromKeys: k andValues: v.
 	s := parseResult disassembleEnv: env.
-	self assert: s key equals: e
+	self assert: s equals: e
 ]
 
 { #category : #arm }
@@ -55,9 +55,7 @@ AcAsmFormatTest >> testBasic [
 	"parserResult is an AcSetAsm"
 	
 	ass := parseResult disassembleEnv: Dictionary new.
-	"disassembly->weight"
-	self assert: ass key equals: 'Simple'.
-	self assert: ass value equals: 0
+	self assert: ass equals: 'Simple'.
 ]
 
 { #category : #generic }
@@ -83,9 +81,7 @@ AcAsmFormatTest >> testEscapePercent [
 	format := self forPowerPC parse: formatString.
 	env := Dictionary new.
 	x := format disassembleEnv: env.
-	self assert: x key equals: 'a%b'.
-	self assert: x value equals: 0
-
+	self assert: x equals: 'a%b'.
 ]
 
 { #category : #sparc }

--- a/src/ArchC-Core-Tests/AcAssemblerTest.class.st
+++ b/src/ArchC-Core-Tests/AcAssemblerTest.class.st
@@ -195,6 +195,25 @@ AcAssemblerTest >> testSC1 [
 { #category : #powerpc }
 AcAssemblerTest >> testTRAP [
 	| result |
+
 	result := AcProcessorDescriptions powerpc assembler parse: 'trap'. "XO1 type"
-	self assert: result binaryEncoding equals: 16r7FE00008 
+	self assert: result binaryEncoding equals: 16r7FE00008.
+	self assert: result disassemble equals: 'trap'.
+
+	result := AcProcessorDescriptions powerpc assembler parse: 'tw 31,0,0'. 
+	self assert: result binaryEncoding equals: 16r7FE00008.                       
+	self assert: result disassemble equals: 'trap'.
+
+	result := AcProcessorDescriptions powerpc assembler parse: 'tweq 0,1'. 
+	self assert: result binaryEncoding equals: 16r7c800808.                       
+	self assert: result disassemble equals: 'tweq 0, 1'.    
+
+	result := AcProcessorDescriptions powerpc assembler parse: 'tw 4,0,1'. 
+	self assert: result binaryEncoding equals: 16r7c800808.                       
+	self assert: result disassemble equals: 'tweq 0, 1'.    
+
+	"trap never"
+	result := AcProcessorDescriptions powerpc assembler parse: 'twi 0,0,0x48'.
+	self assert: result binaryEncoding equals: 16r0c000048.
+	self assert: result disassemble equals: 'twi 0x0, 0, 0x48'
 ]

--- a/src/ArchC-Core-Tests/AcMnemonicTest.class.st
+++ b/src/ArchC-Core-Tests/AcMnemonicTest.class.st
@@ -100,7 +100,7 @@ AcMnemonicTest >> testArmAddPC [
 
 { #category : #'tests - simple' }
 AcMnemonicTest >> testOneBinding [
-	| mnem spec env s numBoundOperands |
+	| mnem spec env s |
 	mnem := '"mov %reg, %reg", rt, rd, c=3'.
 	spec := self forPowerPC parse: mnem.
 	env := Dictionary new 
@@ -109,9 +109,7 @@ AcMnemonicTest >> testOneBinding [
 		at: 'c' put: 3;
 		yourself.
 	s := spec disassembleEnv: env.
-	numBoundOperands := s value.
-	self assert: s key = 'mov 5, 7'.
-	self assert: numBoundOperands = 1
+	self assert: s = 'mov 5, 7'.
 ]
 
 { #category : #'tests - simple' }
@@ -135,7 +133,7 @@ AcMnemonicTest >> testOneReg [
 		at: 'r' put: 5;
 		yourself.
 	s := spec disassembleEnv: env.
-	self assert: s key = 'R 5'
+	self assert: s = 'R 5'
 ]
 
 { #category : #'tests - instructions - PowerPC' }

--- a/src/ArchC-Core-Tests/AcSimpleMnemonicTest.class.st
+++ b/src/ArchC-Core-Tests/AcSimpleMnemonicTest.class.st
@@ -69,7 +69,7 @@ AcSimpleMnemonicTest >> testDisassembleImm [
 	result := spec disassembleEnv: (Dictionary new
 		at: 'd' put: 16r123;
 		yourself).
-	self assert: result = ('abc 0x123' -> 0)
+	self assert: result = 'abc 0x123'
 ]
 
 { #category : #tests }
@@ -101,5 +101,5 @@ AcSimpleMnemonicTest >> testTrivialDisassembly [
 	mnem := '"Literal string"'.
 	spec := self forPowerPC parse: mnem.
 	result := spec disassembleEnv: Dictionary new.
-	self assert: result = ('Literal string' -> 0)
+	self assert: result = 'Literal string'
 ]

--- a/src/ArchC-Core-Tests/SetAsmAssemblerTest.class.st
+++ b/src/ArchC-Core-Tests/SetAsmAssemblerTest.class.st
@@ -88,7 +88,7 @@ SetAsmAssemblerTest >> testTrapPPC [
 SetAsmAssemblerTest >> testTwlgtPPC [
 	| tw trapSetAsm thisParser result |
 	tw := AcProcessorDescriptions powerpc instructionAt: 'tw'.
-	self assert: tw syntax size equals: 2.
+	self assert: tw syntax size equals: 3.
 	trapSetAsm := tw syntax detect: [ :m | m source beginsWith: '"tw' ].
 	thisParser := trapSetAsm assembler.
 	result := thisParser parse: 'twlgt 1, 2'.

--- a/src/ArchC-Core/AcAsmFormat.class.st
+++ b/src/ArchC-Core/AcAsmFormat.class.st
@@ -20,12 +20,16 @@ AcAsmFormat >> assembler [
 
 { #category : #'API - disassembly' }
 AcAsmFormat >> disassembleTo: aWriteStream operands: ops inEnvironment: e [
-	mnemonic disassembleTo: aWriteStream operands: ops inEnvironment: e.
+	(mnemonic disassembleTo: aWriteStream operands: ops inEnvironment: e) ifFalse: [ 
+		^ false
+	].        
 	operands notEmpty ifTrue: [
 		aWriteStream space.
-		operands disassembleTo: aWriteStream operands: ops inEnvironment: e.
-	]
-
+		(operands disassembleTo: aWriteStream operands: ops inEnvironment: e) ifFalse: [ 
+			^ false
+		].
+	].
+	^ true
 ]
 
 { #category : #accessing }

--- a/src/ArchC-Core/AcAsmFormatBuiltinChunk.class.st
+++ b/src/ArchC-Core/AcAsmFormatBuiltinChunk.class.st
@@ -41,13 +41,15 @@ AcAsmFormatBuiltinChunk >> decImmLiteral [
 AcAsmFormatBuiltinChunk >> disassembleTo: aWriteStream operands: ops inEnvironment: e [ 
 	| op |
 
+	ops isEmpty ifTrue: [ ^ false ].
 	op := ops removeFirst.
 	self modifier 
 		disassemble: op
 		to: aWriteStream
 		inEnvironment: e
 		format: instruction format
-		chunk: self
+		chunk: self.
+	^ true
 ]
 
 { #category : #'parsing - private' }

--- a/src/ArchC-Core/AcAsmFormatChunk.class.st
+++ b/src/ArchC-Core/AcAsmFormatChunk.class.st
@@ -90,7 +90,15 @@ AcAsmFormatChunk >> assembler [
 
 { #category : #'API - disassembly' }
 AcAsmFormatChunk >> disassembleTo: aWriteStream operands: ops inEnvironment: e [
-	self subclassResponsibility 
+	"Disassemble a chunk onto a stream according to given environment.
+	 Returns
+	  - `true` if chunk was successfully disassembled
+	  - `false` otherwise.
+
+	 Note, that some text may have been written to stream EVEN IF dissasembly
+	 fails (and this method returned `false`)!
+	"
+	^ self subclassResponsibility
 ]
 
 { #category : #'API - disassembly' }

--- a/src/ArchC-Core/AcAsmFormatLiteralTextChunk.class.st
+++ b/src/ArchC-Core/AcAsmFormatLiteralTextChunk.class.st
@@ -23,8 +23,8 @@ AcAsmFormatLiteralTextChunk >> assembler [
 
 { #category : #'API - disassembly' }
 AcAsmFormatLiteralTextChunk >> disassembleTo: aWriteStream operands: ops inEnvironment: e [
-	aWriteStream nextPutAll: text
-
+	aWriteStream nextPutAll: text.
+	^ true
 ]
 
 { #category : #testing }

--- a/src/ArchC-Core/AcAsmFormatMapChunk.class.st
+++ b/src/ArchC-Core/AcAsmFormatMapChunk.class.st
@@ -48,6 +48,8 @@ AcAsmFormatMapChunk >> assembler [
 { #category : #'API - disassembly' }
 AcAsmFormatMapChunk >> disassembleTo: aWriteStream operands: ops inEnvironment: aDictionary [
 	| op value |
+
+	ops isEmpty ifTrue: [ ^ false ].
 	op := ops removeFirst operand.
 	value := aDictionary at: op.
 	(value isAST and:[value isSymbolic]) ifTrue: [
@@ -58,9 +60,10 @@ AcAsmFormatMapChunk >> disassembleTo: aWriteStream operands: ops inEnvironment: 
 	] ifFalse: [ 
 		| name |
 
-		name := (self map backLookup: value) name.
+		name := (self map backLookup: value ifAbsent:[^ false]) name.
 		aWriteStream nextPutAll: name
 	].
+	^ true
 ]
 
 { #category : #accessing }

--- a/src/ArchC-Core/AcAsmFormatMnemonicChunk.class.st
+++ b/src/ArchC-Core/AcAsmFormatMnemonicChunk.class.st
@@ -28,8 +28,10 @@ AcAsmFormatMnemonicChunk >> assembler [
 
 { #category : #'API - disassembly' }
 AcAsmFormatMnemonicChunk >> disassembleTo: aWriteStream operands: ops inEnvironment: e [
-	subchunks do:[:each | each disassembleTo: aWriteStream operands: ops inEnvironment: e ]
-
+	subchunks do:[:subchunk | 
+		(subchunk disassembleTo: aWriteStream operands: ops inEnvironment: e) ifFalse:[ ^ false ] 
+	].
+	^ true
 ]
 
 { #category : #accessing }

--- a/src/ArchC-Core/AcAsmFormatOperandsChunk.class.st
+++ b/src/ArchC-Core/AcAsmFormatOperandsChunk.class.st
@@ -28,9 +28,9 @@ AcAsmFormatOperandsChunk >> assembler [
 { #category : #'API - disassembly' }
 AcAsmFormatOperandsChunk >> disassembleTo: aWriteStream operands: ops inEnvironment: e [
 	subchunks 
-		do: [:each | each disassembleTo: aWriteStream operands: ops inEnvironment: e ]
-		separatedBy: [aWriteStream nextPut: $,]
-
+		do: [:each | (each disassembleTo: aWriteStream operands: ops inEnvironment: e) ifFalse:[ ^ false ] ]
+		separatedBy: [aWriteStream nextPut: $,].
+	^ true
 ]
 
 { #category : #'printing & storing' }

--- a/src/ArchC-Core/AcAsmFormatSequenceChunk.class.st
+++ b/src/ArchC-Core/AcAsmFormatSequenceChunk.class.st
@@ -27,8 +27,10 @@ AcAsmFormatSequenceChunk >> assembler [
 
 { #category : #'API - disassembly' }
 AcAsmFormatSequenceChunk >> disassembleTo: aWriteStream operands: ops inEnvironment: e [
-	subchunks do:[:each | each disassembleTo: aWriteStream operands: ops inEnvironment: e ]
-
+	subchunks do:[:subchunk | 
+		(subchunk disassembleTo: aWriteStream operands: ops inEnvironment: e) ifFalse:[ ^ false ] 
+	].
+	^ true
 ]
 
 { #category : #'printing & storing' }

--- a/src/ArchC-Core/AcAsmMap.class.st
+++ b/src/ArchC-Core/AcAsmMap.class.st
@@ -16,8 +16,8 @@ AcAsmMap class >> name: aString entries: aCollection [
 ]
 
 { #category : #API }
-AcAsmMap >> backLookup: int [
-	^backMap at: int 
+AcAsmMap >> backLookup: int ifAbsent: block [
+	^backMap at: int ifAbsent: block
 ]
 
 { #category : #accessing }

--- a/src/ArchC-Core/AcAsmSyntax.class.st
+++ b/src/ArchC-Core/AcAsmSyntax.class.st
@@ -79,11 +79,10 @@ AcAsmSyntax >> disassembleEnv: aDictionary [
 	(self constraintsSatisfiedBy: aDictionary) ifFalse: [ ^nil ].
 	operandsToDisassemble := operands asOrderedCollection copy.
 	stream := WriteStream on: String new.
-	^stream contents -> constraints size
-
 	(self format disassembleTo: stream operands: operandsToDisassemble inEnvironment: aDictionary) ifFalse: [ 
 		^ nil
 	].
+	^stream contents
 ]
 
 { #category : #accessing }
@@ -117,6 +116,19 @@ AcAsmSyntax >> instruction: i [
 		format instruction: instruction
 	].  
 
+]
+
+{ #category : #testing }
+AcAsmSyntax >> isMoreOrEquallySpecificThan: another [ 
+	self format operands size < another format operands size ifTrue: [
+		^ true
+	].
+	self format operands size = another format operands size ifTrue: [
+		self constraints size >= another constraints size ifTrue: [
+			^ true
+		].
+	].
+	^ false
 ]
 
 { #category : #accessing }

--- a/src/ArchC-Core/AcAsmSyntax.class.st
+++ b/src/ArchC-Core/AcAsmSyntax.class.st
@@ -75,13 +75,15 @@ AcAsmSyntax >> disassembleEnv: aDictionary [
 	 the most sepecific mnemonic form.
 	OPERAND VALUES IN aDictionary MUST BE CONCRETE."
 	
-	| stream theseOperands |
+	| stream operandsToDisassemble |
 	(self constraintsSatisfiedBy: aDictionary) ifFalse: [ ^nil ].
-	theseOperands := operands asOrderedCollection copy.
+	operandsToDisassemble := operands asOrderedCollection copy.
 	stream := WriteStream on: String new.
-	self format disassembleTo: stream operands: theseOperands inEnvironment: aDictionary.
 	^stream contents -> constraints size
 
+	(self format disassembleTo: stream operands: operandsToDisassemble inEnvironment: aDictionary) ifFalse: [ 
+		^ nil
+	].
 ]
 
 { #category : #accessing }

--- a/src/ArchC-Core/AcProcessorDescription.class.st
+++ b/src/ArchC-Core/AcProcessorDescription.class.st
@@ -269,8 +269,8 @@ AcProcessorDescription >> fillMnemonicsFrom: aCollectionOfAssociations [
 	to the verbatim textual definition of the instruction mnemonic
 	(which can be more than one per instruction)"
 	AcSetAsmParser processAssociations: associations in: self.
-	instructionMnemonics := PPChoiceParser withAll: instructionMnemonics 
-
+	instructions do: [:instruction | instruction syntax sort: [ :a :b | a isMoreOrEquallySpecificThan: b  ] ].
+	instructionMnemonics := PPChoiceParser withAll: instructionMnemonics
 ]
 
 { #category : #'collaboration with parser' }

--- a/src/ArchC-Core/ProcessorInstruction.class.st
+++ b/src/ArchC-Core/ProcessorInstruction.class.st
@@ -79,15 +79,37 @@ ProcessorInstruction >> binaryEncoding [
 	^binaryEncoding
 ]
 
-
-
 { #category : #disassembly }
 ProcessorInstruction >> disassemble [
-	| variants |
-	variants := self syntax collect: [ :each | each disassembleEnv: self allBindingValues ].
-	variants := variants reject: [ :v | v isNil ].
-	variants := variants sorted: [ :a :b | a value > b value ].
-	^variants first key
+	"Disassemble the receiver. If the receiver can be disassembled to (or assembled from)
+	 using different (extended) mnemonics, use the most specific. 
+
+	 For example, on PowerPC an unconditional trap instruction can be written as
+	 `trap` or `tw 31, 0, 0`. In this case, this method will return `trap` as it
+	 is most specific.
+
+	 Similarly, for RISC-V, return from subroutine can be written either as
+	 `jalr zero, ra, 0` or as `ret`. Again, `ret` wil be returned in this case.
+
+	 By 'most specific' we mean the mnemonic that uses least operands.
+	"
+	| bindings |
+
+	bindings := self allBindingValues.
+	self syntax do: [:each |
+		| disassembly |
+
+		disassembly := each disassembleEnv: bindings.
+		disassembly notNil ifTrue: [ 
+			"Please note, that formats are kept sorted by number
+			 of operands so if disassembles, we know it is the
+			 most specific one. See 
+					ProcessorInstructionDeclaration >> #isa:
+					AcProcessorDescription >> #fillMnemonicsFrom:"
+			^ disassembly 
+		]
+	].
+	self error: 'Failed to disassemble'
 ]
 
 { #category : #emitting }

--- a/src/ArchC-Core/ProcessorInstructionDeclaration.class.st
+++ b/src/ArchC-Core/ProcessorInstructionDeclaration.class.st
@@ -77,6 +77,17 @@ ProcessorInstructionDeclaration >> assertInvariants [
 			 description: 'Instruction format '' , format name , '' has not bitfield '' , bitField , ''!'.
 	].
 
+	"ProcessorInstruction >> #disassemble requires syntax formats to be sorted
+	 by increaring number of operands (in assembly language, that is, a comma-separated 
+	 list of operands following mnemonic). Check that.
+
+	 Note, that some instruction may have no syntax defined, hence the nil-check.
+	"
+	syntax notNil ifTrue: [
+		1 to: syntax size - 1 do: [:i | 
+			self assert: ((syntax at: i) isMoreOrEquallySpecificThan: (syntax at: i + 1))
+		].
+	].
 ]
 
 { #category : #accessing }
@@ -90,7 +101,6 @@ ProcessorInstructionDeclaration >> bitWidth [
 
 	^ self format bitWidth
 ]
-
 
 { #category : #'encoding / decoding' }
 ProcessorInstructionDeclaration >> decodeBits: aBitVector [
@@ -171,7 +181,8 @@ ProcessorInstructionDeclaration >> isa: anAcProcessorDescription [
 				syntax at: index put: mnemonicSpec.
 				isa addSyntax: mnemonicSpec assembler                  
 			].
-		]. 
+		].
+		syntax sort: [ :a :b | a isMoreOrEquallySpecificThan: b  ]
 	].
 ]
 


### PR DESCRIPTION
This PR fixes the assembly/disassembly of trap instructions (and other "extended" mnemonics)