### PR TITLE
Signal IllegalInstruction instead of generic Error

### DIFF
--- a/src/ArchC-Core/AcProcessorDescription.class.st
+++ b/src/ArchC-Core/AcProcessorDescription.class.st
@@ -144,9 +144,7 @@ AcProcessorDescription >> decodeBits: aBitVector [
 	candidates := opcodeDecoder instructionsWithOpcodeFitting: aBitVector.
 	candidates := candidates collect: [:instr | instr decodeBits: aBitVector ].
 	candidates := candidates reject: [:instr | instr isNil ].
-	candidates isEmpty ifTrue: [
-		self error: 'Invalid instruction encoding'
-	].
+	candidates isEmpty ifTrue: [ IllegalInstruction signalWith: aBitVector ].
 	^ (candidates 
 		asSortedCollection: [:a :b | a externalBindingBits < b externalBindingBits ]) 
 			first


### PR DESCRIPTION
Consistent with what we do in
OpcodeDecoder>>instructionsWithOpcodeFitting:

That way, tests can properly #should:raise:.
Also disassembler UIs can pretty-print things like <?> when this exception is caught.