### PR TITLE
Add PowerPC64 support

### DIFF
--- a/src/ArchC-Core-Tests/AcAssemblerTest.class.st
+++ b/src/ArchC-Core-Tests/AcAssemblerTest.class.st
@@ -12,11 +12,12 @@ AcAssemblerTest class >> resources [
 
 { #category : #common }
 AcAssemblerTest >> isa: aSymbol assemble: source operandKeys: keys shouldBe: values [
-	| pdl result expected |
+	| pdl result actual expected |
 	pdl := AcProcessorDescriptions perform: aSymbol.
 	result := pdl assembler parse: source.
+	actual := result allBindingValues.
 	expected := Dictionary newFromKeys: keys andValues: values.
-	self assert: result allBindingValues equals: expected 
+	self assert: actual equals: expected
 ]
 
 { #category : #powerpc }

--- a/src/ArchC-Core-Tests/AcAssemblerTest.class.st
+++ b/src/ArchC-Core-Tests/AcAssemblerTest.class.st
@@ -80,6 +80,108 @@ AcAssemblerTest >> testB [
 ]
 
 { #category : #powerpc }
+AcAssemblerTest >> testBC [
+	self
+		isa: #powerpc
+		assemble: 'bc 4, 2, 1234'
+		operandKeys:  #(opcd  aa  lk  bo  bi_cf bi_cb  bd     )
+		shouldBe:     #(16    0   0   4   0     2      308    ).  "<-- 308 = 1234 >> 2. This is because low 2 bits of jump offset are not encoded."
+
+	self
+		isa: #powerpc
+		assemble: 'bne 1234'
+		operandKeys:  #(opcd  aa  lk  bo  bi_cf bi_cb  bd     )
+		shouldBe:     #(16    0   0   4   0     2      308    ).  
+
+	self
+		isa: #powerpc
+		assemble: 'bne cr3, 1234'
+		operandKeys:  #(opcd  aa  lk  bo  bi_cf bi_cb  bd     )
+		shouldBe:     #(16    0   0   4   3     2      308    ).
+]
+
+{ #category : #powerpc }
+AcAssemblerTest >> testBCA [
+	self
+		isa: #powerpc
+		assemble: 'bca 4, 2, 1234'
+		operandKeys:  #(opcd  aa  lk  bo  bi_cf bi_cb  bd     )
+		shouldBe:     #(16    1   0   4   0     2      308    ).  "<-- 308 = 1234 >> 2. This is because low 2 bits of jump offset are not encoded."
+
+	self
+		isa: #powerpc
+		assemble: 'bnea 1234'
+		operandKeys:  #(opcd  aa  lk  bo  bi_cf bi_cb  bd     )
+		shouldBe:     #(16    1   0   4   0     2      308    ).  
+
+	self
+		isa: #powerpc
+		assemble: 'bnea cr3, 1234'
+		operandKeys:  #(opcd  aa  lk  bo  bi_cf bi_cb  bd     )
+		shouldBe:     #(16    1   0   4   3     2      308    ).  
+
+	self
+		isa: #powerpc
+		assemble: 'bnea cr3, 1234'
+		operandKeys:  #(opcd  aa  lk  bo  bi_cf bi_cb  bd     )
+		shouldBe:     #(16    1   0   4   3     2      308    ).
+]
+
+{ #category : #powerpc }
+AcAssemblerTest >> testBCL [
+	self
+		isa: #powerpc
+		assemble: 'bcl 4, 2, 1234'
+		operandKeys:  #(opcd  aa  lk  bo  bi_cf bi_cb  bd     )
+		shouldBe:     #(16    0   1   4   0     2      308    ).  "<-- 308 = 1234 >> 2. This is because low 2 bits of jump offset are not encoded."
+
+	self
+		isa: #powerpc
+		assemble: 'bnel 1234'
+		operandKeys:  #(opcd  aa  lk  bo  bi_cf bi_cb  bd     )
+		shouldBe:     #(16    0   1   4   0     2      308    ).  
+
+	self
+		isa: #powerpc
+		assemble: 'bnel cr3, 1234'
+		operandKeys:  #(opcd  aa  lk  bo  bi_cf bi_cb  bd     )
+		shouldBe:     #(16    0   1   4   3     2      308    ).  
+
+	self
+		isa: #powerpc
+		assemble: 'bnel cr3, 1234'
+		operandKeys:  #(opcd  aa  lk  bo  bi_cf bi_cb  bd     )
+		shouldBe:     #(16    0   1   4   3     2      308    ).
+]
+
+{ #category : #powerpc }
+AcAssemblerTest >> testBCLA [
+	self
+		isa: #powerpc
+		assemble: 'bcla 4, 2, 1234'
+		operandKeys:  #(opcd  aa  lk  bo  bi_cf bi_cb  bd     )
+		shouldBe:     #(16    1   1   4   0     2      308    ).  "<-- 308 = 1234 >> 2. This is because low 2 bits of jump offset are not encoded."
+
+	self
+		isa: #powerpc
+		assemble: 'bnela 1234'
+		operandKeys:  #(opcd  aa  lk  bo  bi_cf bi_cb  bd     )
+		shouldBe:     #(16    1   1   4   0     2      308    ).  
+
+	self
+		isa: #powerpc
+		assemble: 'bnela cr3, 1234'
+		operandKeys:  #(opcd  aa  lk  bo  bi_cf bi_cb  bd     )
+		shouldBe:     #(16    1   1   4   3     2      308    ).  
+
+	self
+		isa: #powerpc
+		assemble: 'bnela cr3, 1234'
+		operandKeys:  #(opcd  aa  lk  bo  bi_cf bi_cb  bd     )
+		shouldBe:     #(16    1   1   4   3     2      308    ).
+]
+
+{ #category : #powerpc }
 AcAssemblerTest >> testExpressionImm [
 	| pdl instr binary concretePart offset |
 	pdl := AcProcessorDescriptions powerpc.

--- a/src/ArchC-Core-Tests/AcAssemblerTest.class.st
+++ b/src/ArchC-Core-Tests/AcAssemblerTest.class.st
@@ -76,8 +76,7 @@ AcAssemblerTest >> testB [
 		isa: #powerpc
 		assemble: 'b 1234'
 		operandKeys:  #(opcd  aa  lk  li     )
-		shouldBe:     #(18    0   0   1234   ).
-
+		shouldBe:     #(18    0   0   308    ).  "<-- 308 = 1234 >> 2. This is because low 2 bits of jump offset are not encoded."
 ]
 
 { #category : #powerpc }

--- a/src/ArchC-Core-Tests/TextDisassemblyTest.class.st
+++ b/src/ArchC-Core-Tests/TextDisassemblyTest.class.st
@@ -27,7 +27,7 @@ TextDisassemblyTest >> testEndianPalindrome [
 	| pdl |
 	pdl := AcProcessorDescriptions powerpc.
 	self assert: (pdl disassemble: 16r08000048) equals: 'tdi 0x0, 0, 0x48'.
-	self assert: (pdl disassemble: 16r48000008) equals: 'b .+0x2'. "actually wrong, but that's how we count instruction offsets for now"
+	self assert: (pdl disassemble: 16r48000008) equals: 'b .+0x8'.
 
 	
 ]

--- a/src/ArchC-Core-Tests/TextDisassemblyTest.class.st
+++ b/src/ArchC-Core-Tests/TextDisassemblyTest.class.st
@@ -40,6 +40,29 @@ TextDisassemblyTest >> testPowerAdd [
 ]
 
 { #category : #'tests - powerpc' }
+TextDisassemblyTest >> testPowerBranchMnemonicsIncorporatingConditions [
+	"
+	See Power ISA, Version 3.1B, 
+		Section C.2.3 Branch Mnemonics Incorporating Conditions,
+		Paragraph Examples
+	"
+
+	| instr text |
+
+	instr := AcProcessorDescriptions powerpc assembler parse: 'bc 4,2,0x1234'.
+	text := instr disassemble.
+	self assert: text equals: 'bne .+0x1234'.
+
+	instr := AcProcessorDescriptions powerpc assembler parse: 'bc 4,14,0x1234'.
+	text := instr disassemble.
+	self assert: text equals: 'bne cr3, .+0x1234'.
+
+	instr := AcProcessorDescriptions powerpc assembler parse: 'bcla 12,17,0x1234'.
+	text := instr disassemble.
+	self assert: text equals: 'bgtla cr4, .+0x1234'.
+]
+
+{ #category : #'tests - powerpc' }
 TextDisassemblyTest >> testPowerOriSymbolic [
 	| instr text binary |
 	binary := (16r6283 toBitVector: 16), ('x' toBitVector: 16).

--- a/src/ArchC-Core-Tests/TextDisassemblyTest.class.st
+++ b/src/ArchC-Core-Tests/TextDisassemblyTest.class.st
@@ -25,11 +25,9 @@ TextDisassemblyTest >> testArmLdrPCREL [
 { #category : #'tests - powerpc' }
 TextDisassemblyTest >> testEndianPalindrome [
 	| pdl |
-	pdl := AcProcessorDescriptions powerpc.
+	pdl := AcProcessorDescriptions powerpc64.
 	self assert: (pdl disassemble: 16r08000048) equals: 'tdi 0x0, 0, 0x48'.
 	self assert: (pdl disassemble: 16r48000008) equals: 'b .+0x8'.
-
-	
 ]
 
 { #category : #'tests - powerpc' }

--- a/src/ArchC-Core/AcAsmMap.class.st
+++ b/src/ArchC-Core/AcAsmMap.class.st
@@ -50,11 +50,6 @@ AcAsmMap >> name [
 	^ name
 ]
 
-{ #category : #helpers }
-AcAsmMap >> name2self [
-	^self name -> self
-]
-
 { #category : #accessing }
 AcAsmMap >> name: anObject [
 	name := anObject

--- a/src/ArchC-Core/AcProcessorDescription.class.st
+++ b/src/ArchC-Core/AcProcessorDescription.class.st
@@ -205,9 +205,12 @@ AcProcessorDescription >> fillFrom: aCollectionOfAssociations [
 	wordsize := (aCollectionOfAssociations detect: [ :ass | ass key = 'ac_wordsize' ]) value.
 	endian := (aCollectionOfAssociations detect: [ :ass | ass key = 'endian' ]) value.
 
-	self
-		fillISAFrom: ((aCollectionOfAssociations detect: [ :ass | ass key = 'ac_isa' ]) value).
-		
+	aCollectionOfAssociations do: [:each | 
+		each key = 'ac_isa' ifTrue: [ self fillISAFrom: each value ]
+	].
+
+	instructionMnemonics := PPChoiceParser withAll: instructionMnemonics.
+
 	^self
 ]
 
@@ -228,7 +231,6 @@ AcProcessorDescription >> fillISAFrom: aCollectionOfAssociations [
 
 { #category : #'collaboration with parser' }
 AcProcessorDescription >> fillInstructionFormatsFrom: aCollectionOfAssociations [
-	instructionFormats := Dictionary new.
 	aCollectionOfAssociations do: [:assoc | 
 		assoc key = 'ac_format' ifTrue: [ 
 			| format |
@@ -240,12 +242,10 @@ AcProcessorDescription >> fillInstructionFormatsFrom: aCollectionOfAssociations 
 			instructionFormats at: format name asSymbol put: format.
 		].        
 	].
-
 ]
 
 { #category : #'collaboration with parser' }
 AcProcessorDescription >> fillInstructionsFrom: aCollectionOfAssociations [
-	instructions := Dictionary new.
 	aCollectionOfAssociations do: [:assoc |  
 		assoc key = 'ac_instr' ifTrue: [ 
 			| instruction |
@@ -258,16 +258,15 @@ AcProcessorDescription >> fillInstructionsFrom: aCollectionOfAssociations [
 			instructions at: instruction name put: instruction.
 		].
 	].
-
 ]
 
 { #category : #'collaboration with parser' }
 AcProcessorDescription >> fillMapsFrom: aCollectionOfAssociations [
-	| mapAssociations m |
-	mapAssociations := aCollectionOfAssociations select: [ :ass |
-		ass key = 'ac_map'].
-	m := mapAssociations collect: [ :ass | ass value name2self ].
-	maps := Dictionary newFromAssociations: m
+	aCollectionOfAssociations do: [ :ass |
+		ass key = 'ac_map' ifTrue: [ 
+			maps at: ass value name put: ass value
+		].
+	].
 ]
 
 { #category : #'collaboration with parser' }
@@ -285,7 +284,6 @@ AcProcessorDescription >> fillMnemonicsFrom: aCollectionOfAssociations [
 	(which can be more than one per instruction)"
 	AcSetAsmParser processAssociations: associations in: self.
 	instructions do: [:instruction | instruction syntax sort: [ :a :b | a isMoreOrEquallySpecificThan: b  ] ].
-	instructionMnemonics := PPChoiceParser withAll: instructionMnemonics
 ]
 
 { #category : #'collaboration with parser' }
@@ -356,11 +354,11 @@ AcProcessorDescription >> initialize [
 	"  memories := nil."
 	"  regbanks := nil."
 	"  regs := nil."
-	"  maps := nil."
+	maps := Dictionary new.
 	"  wordsize := nil."
 	"  endian := nil."
-	"  instructionFormats := nil."
-	"  instructions := nil."
+	instructionFormats := Dictionary new.
+	instructions := Dictionary new.
 	"  regsInGPacket := nil."
 	"  tgtimm := nil."
 	"  architectureName := nil."

--- a/src/ArchC-Core/AcProcessorDescriptions.class.st
+++ b/src/ArchC-Core/AcProcessorDescriptions.class.st
@@ -140,6 +140,12 @@ AcProcessorDescriptions class >> powerpc [
 	^self processor: 'powerpc' in: 'powerpc'
 ]
 
+{ #category : #'known processors' }
+AcProcessorDescriptions class >> powerpc64 [
+	<gtExample>
+	^self processor: 'powerpc64' in: 'powerpc'
+]
+
 { #category : #cache }
 AcProcessorDescriptions class >> processor: isaName in: dir [
 	^self cachedProcessors at: isaName ifAbsentPut: [

--- a/src/ArchC-Core/PCREL.class.st
+++ b/src/ArchC-Core/PCREL.class.st
@@ -10,21 +10,40 @@ PCREL class >> decode: bitfields fromFields: operandInstantiation accordingTo: f
 ]
 
 { #category : #disassembling }
-PCREL class >> disassemble: anOperandInstantiation to: aWriteStream inEnvironment: e format: f chunk: anObject [ 
-	| subfieldValues  li |
+PCREL class >> disassemble: anOperandInstantiation to: aWriteStream inEnvironment: e format: f chunk: anObject [
+	| value |
 
-	subfieldValues := anOperandInstantiation inEnvironment: e format: f.
-	subfieldValues size = 1 ifFalse: [
-		self error
+	value := (self decode: e fromFields: anOperandInstantiation accordingTo: f) simplify.
+
+	value isSymbolic ifTrue: [
+		| variables |
+
+		aWriteStream nextPut: ${.
+		"Original code was:
+
+			aWriteStream nextPutAll: value astToString.
+		"
+		variables := value variableNames.
+		variables size == 1 ifTrue: [ 
+			"Simple function of one variable"
+			aWriteStream nextPutAll: variables anyOne.
+		] ifFalse: [ 
+			"Function of multiple variables, print the whole AST"
+			aWriteStream nextPutAll: value astToString.
+		].
+		aWriteStream nextPut: $} 
+	] ifFalse: [
+		value := value value.    
+		value positive ifTrue: [ 
+			aWriteStream nextPutAll: '.+0x'.
+		] ifFalse: [ 
+			aWriteStream nextPutAll: '.-0x'.
+		].
+		value abs
+			printOn: aWriteStream
+			base: 16
+			showRadix: false
 	].
-	li := subfieldValues first value.
-	aWriteStream nextPutAll: (li positive ifTrue: [
-				'.+0x'
-			] ifFalse: [ '.-0x' ]).
-	li abs 
-		printOn: aWriteStream
-		base: 16
-		showRadix: false
 ]
 
 { #category : #API }

--- a/src/ArchC-Core/PCREL.class.st
+++ b/src/ArchC-Core/PCREL.class.st
@@ -4,6 +4,11 @@ Class {
 	#category : #'ArchC-Core-Parsing'
 }
 
+{ #category : #API }
+PCREL class >> decode: bitfields fromFields: operandInstantiation accordingTo: format [
+	^ (operandInstantiation decode: bitfields accordingTo: format) << 2
+]
+
 { #category : #disassembling }
 PCREL class >> disassemble: anOperandInstantiation to: aWriteStream inEnvironment: e format: f chunk: anObject [ 
 	| subfieldValues  li |
@@ -24,6 +29,9 @@ PCREL class >> disassemble: anOperandInstantiation to: aWriteStream inEnvironmen
 
 { #category : #API }
 PCREL >> encodeInFields: fs accordingTo: format [
-	^ self encode: self x inFields: fs accordingTo: format
+	| width value |
 
+	width := (fs widthAccordingTo: format).
+	value := self x toBitVector: width.
+	^ self encode: (value bitShiftRightArithmetic: 2) inFields: fs accordingTo: format
 ]

--- a/src/ArchC-Core/ProcessorInstruction.class.st
+++ b/src/ArchC-Core/ProcessorInstruction.class.st
@@ -135,9 +135,10 @@ ProcessorInstruction >> inspectorExtraAttributes [
 	| attrs |
 
 	attrs := super inspectorExtraAttributes.
-	attrs at: '-encoding' put: (String streamContents: [:s | self printEncodingOn: s]).
+	attrs at: '-encoding' put: [ String streamContents: [:s | self printEncodingOn: s]].
+	attrs at: '-externalBindings' put: [self externalBindings].
+	attrs at: '-allBindings' put: [self allBindingValues].
 	^attrs
-
 ]
 
 { #category : #testing }

--- a/src/ArchC-DSL/AcAsmSyntax.extension.st
+++ b/src/ArchC-DSL/AcAsmSyntax.extension.st
@@ -8,6 +8,19 @@ AcAsmSyntax >> assembleDSL: mnemonic operands: operandList [
 
 	environment := Dictionary new.
 	operandIdx := 1.
+	format mnemonic isTextChunk ifFalse: [ 
+		"Mnemonic is composed from text and mapped values, for example in POWER
+		 'bc%[lk]%[aa]' or in ARM 'ldm%cond%lstype'. Handle this case here."
+
+		(format mnemonic assembler parse: mnemonic) do: [:operandValue |
+			| operandDef  |
+
+			operandDef := self operands at: operandIdx.
+			environment addAll: (operandDef asOperandInstantiation encodeValue: operandValue accoringTo: instruction format).
+			operandIdx := operandIdx + 1.  
+		].
+	].
+
 	operandList with: format operands  do: [:operandValue :operandFormat |
 		self assert: operandValue isAcDSLMemRef == operandFormat isMemRefChunk.
 

--- a/src/ArchC-DSL/AcDSLPPC32Assembler.class.st
+++ b/src/ArchC-DSL/AcDSLPPC32Assembler.class.st
@@ -13,3 +13,9 @@ AcDSLPPC32Assembler class >> initialize [
 AcDSLPPC32Assembler class >> isa [
 	^ AcProcessorDescriptions powerpc
 ]
+
+{ #category : #extended }
+AcDSLPPC32Assembler >> mr: operands [
+	self assert: operands size == 2.
+	 ^ self append: 'or' operands: (operands copyWith: operands last).
+]

--- a/src/ArchC-DSL/AcDSLPPC64Assembler.class.st
+++ b/src/ArchC-DSL/AcDSLPPC64Assembler.class.st
@@ -1,0 +1,10 @@
+Class {
+	#name : #AcDSLPPC64Assembler,
+	#superclass : #AcDSLAssembler,
+	#category : #'ArchC-DSL'
+}
+
+{ #category : #accessing }
+AcDSLPPC64Assembler class >> isa [
+	^ AcProcessorDescriptions powerpc64
+]

--- a/src/ArchC-DSL/AcDSLPPC64Assembler.class.st
+++ b/src/ArchC-DSL/AcDSLPPC64Assembler.class.st
@@ -8,3 +8,9 @@ Class {
 AcDSLPPC64Assembler class >> isa [
 	^ AcProcessorDescriptions powerpc64
 ]
+
+{ #category : #extended }
+AcDSLPPC64Assembler >> mr: operands [
+	self assert: operands size == 2.
+	 ^ self append: 'or' operands: (operands copyWith: operands last).
+]

--- a/src/ArchC-DSL/AcProcessorDescription.extension.st
+++ b/src/ArchC-DSL/AcProcessorDescription.extension.st
@@ -4,9 +4,11 @@ Extension { #name : #AcProcessorDescription }
 AcProcessorDescription >> assembleDSL: mnemonic operands: operands [
 	self instructions do: [:instruction | 
 		instruction syntax do: [:syntax | 
-			syntax mnemonics do: [:each | 
-				mnemonic = each ifTrue: [ 
-					^ syntax assembleDSL: mnemonic operands: operands
+			syntax format operands size = operands size ifTrue: [
+				syntax mnemonics do: [:each | 
+					mnemonic = each ifTrue: [ 
+						^ syntax assembleDSL: mnemonic operands: operands
+					].
 				].
 			].
 		].


### PR DESCRIPTION
This PR add support for powerpc64 and for conditional branch mnemonics incorporating conditions (bne and so on). It requires corresponing changes in PDLs, see https://github.com/janvrany/Pharo-ArchC-PDL/pull/5.