### PR TITLE
Improve syntax for symbolic jump targets

### DIFF
--- a/src/ArchC-Core-Tests/AcSimpleMnemonicTest.class.st
+++ b/src/ArchC-Core-Tests/AcSimpleMnemonicTest.class.st
@@ -96,6 +96,27 @@ AcSimpleMnemonicTest >> testSymbolicExp [
 ]
 
 { #category : #tests }
+AcSimpleMnemonicTest >> testSymbolicExp2 [
+	| mnem parser spec result |
+	mnem := '"fbl %imm(pcrel)", d'.
+	parser := self forPowerPC.
+	spec := parser parse: mnem.
+	spec instruction: (MockFormatPoznavach format: 'D3' pdl: parser pdl).
+
+	result := spec assembler parse: 'fbl {some_label}'.
+	self assert: (result at: 'd') variables size equals: 1.
+	self assert: (result at: 'd') variables anyOne equals: 'some_label'.
+
+	result := spec assembler parse: 'fbl some_label'.
+	self assert: (result at: 'd') variables size equals: 1.
+	self assert: (result at: 'd') variables anyOne equals: 'some_label'.
+
+	result := spec assembler parse: 'fbl {some funny label}'.
+	self assert: (result at: 'd') variables size equals: 1.
+	self assert: (result at: 'd') variables anyOne equals: 'some funny label'.
+]
+
+{ #category : #tests }
 AcSimpleMnemonicTest >> testTrivialDisassembly [
 	| mnem spec result |
 	mnem := '"Literal string"'.

--- a/src/ArchC-Core/AcAsmFormatBuiltinChunk.class.st
+++ b/src/ArchC-Core/AcAsmFormatBuiltinChunk.class.st
@@ -16,8 +16,14 @@ Class {
 
 { #category : #'API - assembly' }
 AcAsmFormatBuiltinChunk >> assembler [
-	^self immLiteral / self immExpression ==> [ :x | { modifier new x: x; yourself } ]
+	| assembler |
+	(modifier notNil and: [ modifier isPCREL ]) ifTrue: [
+		assembler := self pcrelLiteral / self pcrelExpression
+	] ifFalse: [ 
+		assembler := self immLiteral / self immExpression
+	].
 
+	^ assembler ==> [ :x | { modifier new x: x; yourself } ]
 ]
 
 { #category : #'parsing - private' }
@@ -38,6 +44,23 @@ AcAsmFormatBuiltinChunk >> disassembleTo: aWriteStream operands: ops inEnvironme
 		format: instruction format
 		chunk: self.
 	^ true
+]
+
+{ #category : #'parsing - private' }
+AcAsmFormatBuiltinChunk >> gasLabel [
+	"Parse GNU assembler style label. 
+
+	 See https://sourceware.org/binutils/docs/as/Labels.html
+	"
+	| first rest |
+
+	first := ($_ asParser / $. asParser / $$ asParser / #letter asParser).
+	rest  := ($_ asParser / $. asParser / $$ asParser / #letter asParser / #digit asParser) star.
+	^ (first, rest) token ==> [ :token | token inputValue ]
+
+	"
+	(AcAsmFormatBuiltinChunk new gasLabel parse: '.l_99')
+	"
 ]
 
 { #category : #'parsing - private' }
@@ -81,6 +104,27 @@ AcAsmFormatBuiltinChunk >> modifier [
 { #category : #accessing }
 AcAsmFormatBuiltinChunk >> modifier: anObject [
 	modifier := anObject
+]
+
+{ #category : #'parsing - private' }
+AcAsmFormatBuiltinChunk >> pcrelExpression [
+	"As a convenience allow PC-relative symbolic values be written also
+	 as (GNU) assembler labels in addition to usual curly-braces syntax."
+
+	^ self gasLabel / self immExpression
+
+	"
+	(AcAsmFormatBuiltinChunk new pcrelExpression parse: '.l_99')
+	(AcAsmFormatBuiltinChunk new pcrelExpression parse: 'some_label')
+	(AcAsmFormatBuiltinChunk new pcrelExpression parse: '{some_label}')
+	(AcAsmFormatBuiltinChunk new pcrelExpression parse: '{a+b}')
+	(AcAsmFormatBuiltinChunk new pcrelExpression parse: 'a+b')
+	"
+]
+
+{ #category : #'parsing - private' }
+AcAsmFormatBuiltinChunk >> pcrelLiteral [
+	^ self immLiteral
 ]
 
 { #category : #accessing }

--- a/src/ArchC-Core/AcAsmFormatChunk.class.st
+++ b/src/ArchC-Core/AcAsmFormatChunk.class.st
@@ -106,7 +106,7 @@ AcAsmFormatChunk >> disassembleTo: aWriteStream operands: ops inEnvironment: e [
 	^ self subclassResponsibility
 ]
 
-{ #category : #'API - disassembly' }
+{ #category : #'parsing - private' }
 AcAsmFormatChunk >> immExpression [
 	^${ asParser, (PPPredicateObjectParser anyExceptAnyOf: #($})) star flatten, $} asParser
 	==> [ :expr | expr second "the string inside {...} will become the variable name" ]

--- a/src/ArchC-Core/AcAsmOperandModifier.class.st
+++ b/src/ArchC-Core/AcAsmOperandModifier.class.st
@@ -56,6 +56,11 @@ AcAsmOperandModifier class >> disassemble: anOperandInstantiation to: aWriteStre
 	].
 ]
 
+{ #category : #queries }
+AcAsmOperandModifier class >> isPCREL [
+	^ false
+]
+
 { #category : #'printing & storing' }
 AcAsmOperandModifier class >> unparseOn: aStream [
 	"See AcAsmFormatChunk >> #unparseOn:"
@@ -75,6 +80,11 @@ AcAsmOperandModifier >> encode: value inFields: fs accordingTo: format [
 { #category : #API }
 AcAsmOperandModifier >> encodeInFields: fs accordingTo: format [
 	self subclassResponsibility 
+]
+
+{ #category : #queries }
+AcAsmOperandModifier >> isPRREL [
+	^ self class isPCREL
 ]
 
 { #category : #accessing }

--- a/src/ArchC-Core/AcSetAsmParser.class.st
+++ b/src/ArchC-Core/AcSetAsmParser.class.st
@@ -42,7 +42,7 @@ AcSetAsmParser >> parse: s [
 	formatString := s copyFrom: quote1 + 1 to: quote2 - 1.
 	format := (AcAsmFormatParser maps: self pdl maps) parse: formatString.
 	format isPetitFailure ifTrue: [
-		self error
+		self error: format printString
 	].
 	opString := s copyFrom: quote2 + 1 to: s size.
 	op := (AcAsmOperandsParser pdl: self pdl) parse: opString.

--- a/src/ArchC-Core/PCREL.class.st
+++ b/src/ArchC-Core/PCREL.class.st
@@ -18,22 +18,32 @@ PCREL class >> disassemble: anOperandInstantiation to: aWriteStream inEnvironmen
 	value isSymbolic ifTrue: [
 		| variables |
 
-		aWriteStream nextPut: ${.
-		"Original code was:
-
-			aWriteStream nextPutAll: value astToString.
-		"
 		variables := value variableNames.
 		variables size == 1 ifTrue: [ 
-			"Simple function of one variable"
-			aWriteStream nextPutAll: variables anyOne.
+			"If the variable name is valid (GNU) assembler label name,
+			 output it without braces. See AcAsmFormatBuiltinChunk >> #assembler."
+			| name |
+
+			name := variables anyOne.
+			((name allSatisfy:[:c | c isAlphaNumeric or:['_.$' includes:c]]) and: [ name first isDigit not ]) ifTrue: [ 
+				"Valid (GNU) assembler label"
+				aWriteStream nextPutAll: name.
+			] ifFalse: [ 
+				"Anything else"
+				aWriteStream 
+					nextPut: ${;
+					nextPutAll: name;
+					nextPut: $}.
+			].
 		] ifFalse: [ 
 			"Function of multiple variables, print the whole AST"
-			aWriteStream nextPutAll: value astToString.
+			aWriteStream 
+					nextPut: ${;
+					nextPutAll: value astToString;
+					nextPut: $}.
 		].
-		aWriteStream nextPut: $} 
 	] ifFalse: [
-		value := value value.    
+		value := value signedValue.    
 		value positive ifTrue: [ 
 			aWriteStream nextPutAll: '.+0x'.
 		] ifFalse: [ 
@@ -44,6 +54,11 @@ PCREL class >> disassemble: anOperandInstantiation to: aWriteStream inEnvironmen
 			base: 16
 			showRadix: false
 	].
+]
+
+{ #category : #queries }
+PCREL class >> isPCREL [
+	^ true
 ]
 
 { #category : #API }

--- a/src/ArchC-Core/PCRELLDR.class.st
+++ b/src/ArchC-Core/PCRELLDR.class.st
@@ -26,6 +26,11 @@ PCRELLDR class >> imm12Of: x [
 	^x abs
 ]
 
+{ #category : #queries }
+PCRELLDR class >> isPCREL [
+	^ true
+]
+
 { #category : #encoding }
 PCRELLDR class >> uOf: x [
 	"ARM u+imm12 encoding"

--- a/src/ArchC-Core/PCRELROT.class.st
+++ b/src/ArchC-Core/PCRELROT.class.st
@@ -3,3 +3,8 @@ Class {
 	#superclass : #AcAsmOperandModifier,
 	#category : #'ArchC-Core-Parsing'
 }
+
+{ #category : #queries }
+PCRELROT class >> isPCREL [
+	^ true
+]

--- a/src/ArchC-RISCV-Tests/AcRISCVTests.class.st
+++ b/src/ArchC-RISCV-Tests/AcRISCVTests.class.st
@@ -77,11 +77,17 @@ AcRISCVTests >> testRiscvBNE [
 
 	insn := pdl assembler parse: 'bne  a5,  a3    , -12'.
 	self assert: insn asByteArray equals: #[ 16re3 16r9a 16rd7 16rfe ].
-	self assert: insn disassemble equals: 'bne a5, a3, -12'.
+	self assert: insn disassemble equals: 'bne a5, a3, .-0xC'.
 
 	"Test jump to label"
+	insn := pdl assembler parse: 'bne  a5, a3, {lab el}'.
+	self assert: insn disassemble equals: 'bne a5, a3, {lab el}'.
+
 	insn := pdl assembler parse: 'bne  a5, a3, {label}'.
-	self assert: insn disassemble equals: 'bne a5, a3, {label}'.
+	self assert: insn disassemble equals: 'bne a5, a3, label'.
+
+	insn := pdl assembler parse: 'bne  a5, a3, label'.
+	self assert: insn disassemble equals: 'bne a5, a3, label'.
 ]
 
 { #category : #'tests - RISC-V' }

--- a/src/ArchC-RISCV/BIMM16.class.st
+++ b/src/ArchC-RISCV/BIMM16.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : #BIMM16,
-	#superclass : #AcAsmOperandModifier,
+	#superclass : #PCREL,
 	#category : #'ArchC-RISCV-Parsing'
 }
 


### PR DESCRIPTION
Up to now, assembler (and disassembler) allowed one to notate symbolic
values by enclosing them in curly braces, for example:

    bne x10, x11, {label}

This PR extends assembler (and disassembler) to allow one to omit
curly braces when the name of symbolic variable is a valid (GNU)
assembler label [1]. The above can now can be notated like:

    bne x10, x11, label

The main motivation behind this is to allow one to produce (readable)
assembly source for external (GNU) assemblers.

For now omitting curly braces is only allowed for jump targets (technically 
for any immediate with PC-relative-like modifier). This may change in
the future. 

[1]: https://sourceware.org/binutils/docs-2.40/as/Labels.html