### PR TITLE
Fix `AcInstrDecodeTest>>testPowerAddiSymbolic`

### DIFF
--- a/src/ArchC-Core-Tests/AcInstrDecodeTest.class.st
+++ b/src/ArchC-Core-Tests/AcInstrDecodeTest.class.st
@@ -65,7 +65,7 @@ AcInstrDecodeTest >> testPowerAddiSymbolic [
 	self assert: instr name equals: 'addi'.
 	self assert: (instr fieldValue: 'rt') equals: 0.
 	self assert: (instr fieldValue: 'ra') equals: 0.
-	self assert: (instr fieldValue: 'd') equals: 'x'.
+	self assert: (instr fieldValue: 'd') equals: ('x'///16) toSignedInt .
 	
 ]
 

--- a/src/ArchC-Core-Tests/AcInstrDecodeTest.class.st
+++ b/src/ArchC-Core-Tests/AcInstrDecodeTest.class.st
@@ -60,7 +60,7 @@ AcInstrDecodeTest >> testPowerAddi [
 { #category : #powerpc }
 AcInstrDecodeTest >> testPowerAddiSymbolic [
 	| binary instr |
-	binary := (16r3800 toBitVector: 16), ('x' toBitVector: 16).   "addi r0, r0, 0, aka li r0, 0"
+	binary := (16r3800 toBitVector: 16), ('x' toBitVector: 16).   "li r0, x"
 	instr := AcProcessorDescriptions powerpc decode: binary.
 	self assert: instr name equals: 'addi'.
 	self assert: (instr fieldValue: 'rt') equals: 0.


### PR DESCRIPTION
A trivial push yesterday (classifying a method) re-triggered CI and now https://github.com/shingarov/Pharo-ArchC/actions/runs/9171675951/job/25216516144 .  I don't understand how this could possibly pass before.