### PR TITLE
Add "data instructions"

### DIFF
--- a/src/ArchC-Core-Tests/AcAssemblerTest.class.st
+++ b/src/ArchC-Core-Tests/AcAssemblerTest.class.st
@@ -313,3 +313,39 @@ AcAssemblerTest >> testTRAP [
 	self assert: result binaryEncoding equals: 16r0c000048.
 	self assert: result disassemble equals: 'twi 0x0, 0, 0x48'
 ]
+
+{ #category : #data }
+AcAssemblerTest >> test_byte [
+	| result |
+
+	result := AcProcessorDescriptions powerpc assembler parse: '.byte 0x7F'.
+	self assert: result binaryEncoding equals: 16r7F.
+	self assert: result disassemble equals: '.byte 0x' , (16r7F printStringRadix: 16).
+]
+
+{ #category : #data }
+AcAssemblerTest >> test_u16 [
+	| result |
+
+	result := AcProcessorDescriptions powerpc assembler parse: '.2byte 0x7FE0'.
+	self assert: result binaryEncoding equals: 16r7FE0.
+	self assert: result disassemble equals: '.2byte 0x' , (16r7FE0 printStringRadix:16).
+]
+
+{ #category : #data }
+AcAssemblerTest >> test_u32 [
+	| result |
+
+	result := AcProcessorDescriptions powerpc assembler parse: '.4byte 0x7FE00008'.
+	self assert: result binaryEncoding equals: 16r7FE00008.
+	self assert: result disassemble equals: '.4byte 0x' , (16r7FE00008 printStringRadix:16).
+]
+
+{ #category : #data }
+AcAssemblerTest >> test_u64 [
+	| result |
+
+	result := AcProcessorDescriptions powerpc assembler parse: '.8byte 0x7FE00008CAFEAFFE'.
+	self assert: result binaryEncoding equals: 16r7FE00008CAFEAFFE.
+	self assert: result disassemble equals: '.8byte 0x' , (16r7FE00008CAFEAFFE printStringRadix:16).
+]

--- a/src/ArchC-Core/AcByte.class.st
+++ b/src/ArchC-Core/AcByte.class.st
@@ -1,0 +1,15 @@
+Class {
+	#name : #AcByte,
+	#superclass : #AcInt,
+	#category : #'ArchC-Core-Core'
+}
+
+{ #category : #accessing }
+AcByte >> bitWidth [
+	^ 8
+]
+
+{ #category : #accessing }
+AcByte >> name [
+	^ '.byte'
+]

--- a/src/ArchC-Core/AcDataInstruction.class.st
+++ b/src/ArchC-Core/AcDataInstruction.class.st
@@ -1,0 +1,69 @@
+Class {
+	#name : #AcDataInstruction,
+	#superclass : #AcInstruction,
+	#instVars : [
+		'isa',
+		'binaryEncoding',
+		'relocation'
+	],
+	#category : #'ArchC-Core-Core'
+}
+
+{ #category : #queries }
+AcDataInstruction class >> isAbstract [
+	^ self == AcDataInstruction.
+]
+
+{ #category : #'instance creation' }
+AcDataInstruction class >> value: value [
+	self assert: self isAbstract not description: 'Cannot instantiate abstract class'.
+
+	^ self basicNew
+		value: value;
+		yourself.
+]
+
+{ #category : #accessing }
+AcDataInstruction >> binaryEncoding [
+	^ binaryEncoding
+]
+
+{ #category : #accessing }
+AcDataInstruction >> isa [
+	^ isa
+]
+
+{ #category : #accessing }
+AcDataInstruction >> isa: anAcProcessorDefinition [
+	self assert:(isa isNil or: [ anAcProcessorDefinition == isa ]).
+
+	isa := anAcProcessorDefinition.
+]
+
+{ #category : #accessing }
+AcDataInstruction >> relocation [
+	^ relocation
+]
+
+{ #category : #accessing }
+AcDataInstruction >> relocation: anAcRelocationOrNil [
+	"Set or clear relocation entry associated with this instruction."
+
+	self assert: (anAcRelocationOrNil isNil or: [ anAcRelocationOrNil isAcRelocation ]).
+	self assert: (anAcRelocationOrNil isNil or: [ anAcRelocationOrNil isValidForInstruction: self])
+		 description: 'Invalid data relocation'.
+	self assert: (relocation isNil or: [ anAcRelocationOrNil isNil ])
+		 description: 'A relocation already associated'.
+
+	relocation := anAcRelocationOrNil
+]
+
+{ #category : #accessing }
+AcDataInstruction >> value [
+	^ self subclassResponsibility
+]
+
+{ #category : #accessing }
+AcDataInstruction >> value: value [
+	^ self subclassResponsibility
+]

--- a/src/ArchC-Core/AcInt.class.st
+++ b/src/ArchC-Core/AcInt.class.st
@@ -1,0 +1,54 @@
+Class {
+	#name : #AcInt,
+	#superclass : #AcDataInstruction,
+	#category : #'ArchC-Core-Core'
+}
+
+{ #category : #queries }
+AcInt class >> isAbstract [
+	"Return if this class is an abstract class.
+	 True is returned here for myself only; false for subclasses.
+	 Abstract subclasses must redefine this again."
+
+	^ self == AcInt.
+]
+
+{ #category : #'instance creation' }
+AcInt class >> new [
+	^ self value: 0
+]
+
+{ #category : #'encoding / decoding' }
+AcInt >> assembler [
+	^ (self name asParser trim,
+		(   "hex literal"('0x' asParser, #hex asParser plus flatten ==> [ :prefAndnumeral | Integer readFrom: prefAndnumeral second  base: 16 ])
+		  / "dec literal"(#digit asParser plus flatten ==> [ :numeralString | numeralString asInteger ])
+		  / "{varname}"  (${ asParser, (PPPredicateObjectParser anyExceptAnyOf: #($})) star flatten, $} asParser ==> [ :expr | expr second])))
+		  ==> [ :nameAndValue | self class value: nameAndValue second ].
+
+	"
+	AcByte basicNew assembler parse: '.byte 0x1'
+	AcByte basicNew assembler parse: '.byte 255'
+	AcByte basicNew assembler parse: '.byte {byteval}'
+	"
+]
+
+{ #category : #'encoding / decoding' }
+AcInt >> disassemble [
+	^ self name , ' 0x' , (self value printStringRadix: 16)
+]
+
+{ #category : #'encoding / decoding' }
+AcInt >> emitOn: aStream [
+	self binaryEncoding toByteArrayEndian: self isa endian on: aStream
+]
+
+{ #category : #accessing }
+AcInt >> value [
+	^ self binaryEncoding unsignedValue
+]
+
+{ #category : #accessing }
+AcInt >> value: value [
+	binaryEncoding := value toBitVector: self bitWidth
+]

--- a/src/ArchC-Core/AcInt16.class.st
+++ b/src/ArchC-Core/AcInt16.class.st
@@ -1,0 +1,15 @@
+Class {
+	#name : #AcInt16,
+	#superclass : #AcInt,
+	#category : #'ArchC-Core-Core'
+}
+
+{ #category : #accessing }
+AcInt16 >> bitWidth [
+	^ 16
+]
+
+{ #category : #accessing }
+AcInt16 >> name [
+	^ '.2byte'
+]

--- a/src/ArchC-Core/AcInt32.class.st
+++ b/src/ArchC-Core/AcInt32.class.st
@@ -1,0 +1,15 @@
+Class {
+	#name : #AcInt32,
+	#superclass : #AcInt,
+	#category : #'ArchC-Core-Core'
+}
+
+{ #category : #accessing }
+AcInt32 >> bitWidth [
+	^ 32
+]
+
+{ #category : #accessing }
+AcInt32 >> name [
+	^ '.4byte'
+]

--- a/src/ArchC-Core/AcInt64.class.st
+++ b/src/ArchC-Core/AcInt64.class.st
@@ -1,0 +1,15 @@
+Class {
+	#name : #AcInt64,
+	#superclass : #AcInt,
+	#category : #'ArchC-Core-Core'
+}
+
+{ #category : #accessing }
+AcInt64 >> bitWidth [
+	^ 64
+]
+
+{ #category : #accessing }
+AcInt64 >> name [
+	^ '.8byte'
+]

--- a/src/ArchC-Core/AcOpcodeDecoder.class.st
+++ b/src/ArchC-Core/AcOpcodeDecoder.class.st
@@ -40,6 +40,5 @@ AcOpcodeDecoder >> preDecodeBits: aBitVector [
 	| opcd |
 
 	opcd := aBitVector subrange: opcodeRange.
-	^ instrGroups at: opcd value
-		ifAbsent: [ IllegalInstruction signalWith: aBitVector ]
+	^ instrGroups at: opcd value ifAbsent: [ #() ]
 ]

--- a/src/ArchC-Core/AcProcessorDescription.class.st
+++ b/src/ArchC-Core/AcProcessorDescription.class.st
@@ -351,7 +351,10 @@ AcProcessorDescription >> initialize [
 	"  tgtimm := nil."
 	"  architectureName := nil."
 	"  abi := nil."
-	instructionMnemonics := OrderedCollection new.
+	instructionMnemonics := OrderedCollection with:(AcByte basicNew assembler
+												   /AcInt16 basicNew assembler
+												   /AcInt32 basicNew assembler
+												   /AcInt64 basicNew assembler)
 	"  opcodeDecoder := nil."
 ]
 

--- a/src/ArchC-Core/AcProcessorDescription.class.st
+++ b/src/ArchC-Core/AcProcessorDescription.class.st
@@ -143,7 +143,7 @@ AcProcessorDescription >> decodeBits: aBitVector [
 	candidates := opcodeDecoder preDecodeBits: aBitVector.
 	candidates := candidates collect: [:instr | instr decodeBits: aBitVector ].
 	candidates := candidates reject: [:instr | instr isNil ].
-	candidates isEmpty ifTrue: [ IllegalInstruction signalWith: aBitVector ].
+	candidates isEmpty ifTrue: [ ^ IllegalInstruction signalWith: aBitVector ].
 	^ (candidates 
 		asSortedCollection: [:a :b | a externalBindingBits < b externalBindingBits ]) 
 			first

--- a/src/ArchC-DSL/AcDSLAssembler.class.st
+++ b/src/ArchC-DSL/AcDSLAssembler.class.st
@@ -71,6 +71,25 @@ AcDSLAssembler >> append: mnemonic operands: operands [
 	^ insn.
 ]
 
+{ #category : #'emitting-private' }
+AcDSLAssembler >> appendDC: dataClass operands: operands [
+	operands asAcDSLOperandList do: [:operand |
+		| data |
+
+		data := dataClass new
+					isa: self isa;
+					value: operand;
+					relocation: operand relocation;
+					yourself.
+		self append: data
+	].
+]
+
+{ #category : #'emitting - data' }
+AcDSLAssembler >> byte: bytes [
+	^ self appendDC: AcByte operands: bytes
+]
+
 { #category : #accessing }
 AcDSLAssembler >> cursor: anInteger [
 	memory cursor: anInteger
@@ -99,6 +118,21 @@ AcDSLAssembler >> initialize [
 		AcDSLAssemblerGenerator generate: self class.
 	].
 	memory := AcDSLCodeBuffer new
+]
+
+{ #category : #'emitting - data' }
+AcDSLAssembler >> int16: int16s [
+	^ self appendDC: AcInt16 operands: int16s
+]
+
+{ #category : #'emitting - data' }
+AcDSLAssembler >> int32: int32s [
+	^ self appendDC: AcInt32 operands: int32s
+]
+
+{ #category : #'emitting - data' }
+AcDSLAssembler >> int64: int64s [
+	^ self appendDC: AcInt64 operands: int64s
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
This PR add "data instructions", a kind instruction that is not an
ISA instruction but merely byte value. These allows users to build data
(structures) and code in an uniform way and also simplify embedding data
into instruction stream (when generating trampolines / PLTs, compiled
code headers and so on - all this is common in JIT compilers)
