### PR TITLE
Update dependencies of ArchC-Code

### DIFF
--- a/src/ArchC-Core/ManifestArchCCore.class.st
+++ b/src/ArchC-Core/ManifestArchCCore.class.st
@@ -15,8 +15,8 @@ ManifestArchCCore class >> mandatoryPreRequisites [
 	 Please take a look at the #referencedPreRequisites method as well."
 
 	^ #(
-		#MachineArithmetic    "BitVector - extended"
-		#'MachineArithmetic-FFI-SmalltalkX'    "Z3Object - extended"
+		#'PreSmalltalks' "associationsDo: and co."
+		#'Z3'    "BitVector - extended"
 		#'stx:goodies/petitparser'    "PPCompositeParser - superclass of AcAbiParser"
 		#'stx:libbasic'    "ArrayedCollection - extended"
 		#'stx:libcompat'    "PackageManifest - superclass of ManifestArchCCore"

--- a/stx/GNUmakefile
+++ b/stx/GNUmakefile
@@ -33,13 +33,13 @@ build: prereq
 run: build
 	ARCHC_PDL_DIR=$(ARCHC_PDL_DIR)/ $(STX) \
 		--quick \
-		--package-path $(MACHINEARITHMETIC_DIR) \
+		--package-path $(MACHINEARITHMETIC_DIR)/src \
 		--package-path ../src \
 		--load BaselineOf$(PROJECT) \
 
 test: build
 	ARCHC_PDL_DIR=$(ARCHC_PDL_DIR)/ $(STX) \
-		--package-path $(MACHINEARITHMETIC_DIR) \
+		--package-path $(MACHINEARITHMETIC_DIR)/src \
 		--package-path ../src \
 		--load BaselineOf$(PROJECT) \
 		--run Builder::ReportRunner -r Builder::TestReport --fail-on-failure \


### PR DESCRIPTION
This commit updates Smalltalk/X dependencies for package ArchC-Code after changes in MachineArithmetic that made Z3 proper independent of PreSmalltalks.

Since ArchC code still needs some APIs provided, we need to add it to the dependencies.