### PR TITLE
Fix 2 tests in `InstructionFormatTest` on Smalltalk/X

### DIFF
--- a/src/ArchC-Core-Tests/InstructionFormatTest.class.st
+++ b/src/ArchC-Core-Tests/InstructionFormatTest.class.st
@@ -111,7 +111,7 @@ InstructionFormatTest >> testMostVariedOperands [
 { #category : #'total widths' }
 InstructionFormatTest >> testMostVariedOperandsARM [
 	| instructions max fatInstructions fatInstructionNames |
-	instructions := AcProcessorDescriptions armv5 instructions values.
+	instructions := AcProcessorDescriptions armv5 instructions values asArray.
 	max := instructions inject: 0 into: [ :soFar :instr |
 		| thisWidth |
 		thisWidth := instr externalBindingBits.
@@ -143,7 +143,7 @@ InstructionFormatTest >> testMostVariedOperandsPPC [
 { #category : #'total widths' }
 InstructionFormatTest >> testMostVariedOperandsSPARC [
 	| instructions max fatInstructions fatInstructionNames |
-	instructions := AcProcessorDescriptions sparcv8 instructions values.
+	instructions := AcProcessorDescriptions sparcv8 instructions values asArray.
 	max := instructions inject: 0 into: [ :soFar :instr |
 		| thisWidth |
 		thisWidth := instr externalBindingBits.


### PR DESCRIPTION
This commit tests `InstructionFormatTest >> #testMostVariedOperandsARM` and `#testMostVariedOperandsSPARC` for Smalltalk/X - the problem was that `Dictionary >> values` gives an `Array` on Pharo and OC on St/X.

The reason this worked so far was that Smalltalk/X had a hack in `assert:equals:` to treat comparison of `Array` and `OrderedCollection` specially. While convenient, this is non-standard behavior and hinders portability. Therefore it will be removed from Smalltalk/X and this commit proactively fixes the test.