### PR TITLE
Specify Tonel version in `src/.properties`

### DIFF
--- a/src/.properties
+++ b/src/.properties
@@ -1,3 +1,4 @@
 {
-	#format : #tonel
+	#format : #tonel,
+	#version : #'1.0'
 }


### PR DESCRIPTION
The default Tonel version in (at least) P12 is different than in P8, causing commits made from P12 to reformat all files, resulting in ton of "noise changes". Worse, subsequent commit from P8 would change everything back.

To avoid this issue, explicitly specify Tonel version 1.0.